### PR TITLE
html-encoder-decoder 1.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 
-# html-encoder-decoder [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/html-encoder-decoder.svg)](https://www.npmjs.com/package/html-encoder-decoder) [![Downloads](https://img.shields.io/npm/dt/html-encoder-decoder.svg)](https://www.npmjs.com/package/html-encoder-decoder) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+# html-encoder-decoder
+
+ [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Version](https://img.shields.io/npm/v/html-encoder-decoder.svg)](https://www.npmjs.com/package/html-encoder-decoder) [![Downloads](https://img.shields.io/npm/dt/html-encoder-decoder.svg)](https://www.npmjs.com/package/html-encoder-decoder) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > HTML Encoder / Decoder - Converts characters to their corresponding HTML Entities
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "html-encoder-decoder",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "HTML Encoder / Decoder - Converts characters to their corresponding HTML Entities",
   "main": "index.js",
   "scripts": {
@@ -33,6 +33,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ]


### PR DESCRIPTION
 - Updated the README.md following the new template. :memo:
 - Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.